### PR TITLE
Add omarchy-c64-theme to Themes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Omarchy is an opinionated Arch Linux/Hyprland configuration that transforms a fr
 - [omarchy-bauhaus-theme](https://github.com/somerocketeer/omarchy-bauhaus-theme) - Minimalist theme inspired by Bauhaus design principles.
 - [omarchy-blackturq-theme](https://github.com/HANCORE-linux/omarchy-blackturq-theme) - Black turquoise theme based on Evo80 keyboard color pattern.
 - [omarchy-blueridge-dark-theme](https://github.com/hipsterusername/omarchy-blueridge-dark-theme) - Dark theme inspired by mountain ridge aesthetics.
+- [omarchy-c64-theme](https://github.com/scar45/omarchy-c64-theme) - Nostalgic double-blue theme inspired by the Commodore 64.
 - [omarchy-cobalt2-theme](https://github.com/hoblin/omarchy-cobalt2-theme) - Cobalt2 theme inspired by the iconic VSCode theme.
 - [omarchy-crimson-gold-theme](https://github.com/knappkevin/omarchy-crimson-gold-theme) - Luxurious crimson and gold color combination.
 - [omarchy-dracula-theme](https://github.com/catlee/omarchy-dracula-theme) - Popular Dracula theme adaptation.


### PR DESCRIPTION
## Description
Brief description of what you're adding/changing.

## Type of Contribution
- [X] New resource (theme, tool, tutorial, etc.)
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please specify)

## Resource Details
<!-- Fill out if adding a new resource -->
- **Resource Name**: omarchy-c64-theme
- **Category**: Themes
- **Link**: https://github.com/scar45/omarchy-c64-theme
- **Description**: Nostalgic double-blue theme inspired by the Commodore 64.

## Checklist
- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I have tested all links and they work
- [X] The resource is relevant to Omarchy
- [X] The description is clear and concise
- [X] I have followed the formatting guidelines
- [X] I have added the resource to the appropriate section
- [X] I have maintained alphabetical order within the section
- [X] The resource meets the quality standards outlined in CONTRIBUTING.md

## Additional Notes
<!-- Any additional information or context about this contribution -->
