### PR TITLE
Remove empty omarchy-fairyfloss-theme from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@
 - [omarchy-arc-blueberry](https://github.com/vale-c/omarchy-arc-blueberry) - Arc Blueberry inspired colors tailored for Omarchy.
 - [omarchy-ayu-dark-theme](https://github.com/fdidron/omarchy-ayu-dark-theme) - Omarchy Ayu Dark Theme.
 - [omarchy-ayu-light-theme](https://github.com/fdidron/omarchy-ayu-light-theme) - Omarchy Ayu Light Theme.
-- [omarchy-fairyfloss-theme](https://github.com/jackdbai/omarchy-fairyfloss-theme) - Fairyfloss theme for Omarchy.
 - [omarchy-github-light-theme](https://github.com/ryanyogan/omarchy-github-light-theme) - GitHub Light theme adaptation.
 - [omarchy-night-owl-theme](https://github.com/maxberggren/omarchy-night-owl-theme) - Dark blue night owl theme for Omarchy.
 - [omarchy-catppuccin-mocha-theme](https://github.com/KidDogDad/omarchy-catppuccin-mocha-theme) - Catppuccin Mocha theme for Omarchy.


### PR DESCRIPTION
Removed the Fairyfloss theme entry from the list of Omarchy themes, as the repository is empty.

## Description
removed Fairyfloss theme, as the repository it links to is empty

## Type of Contribution
- [ ] New resource (theme, tool, tutorial, etc.)
- [ ] Update existing entry
- [x] Fix broken link
- [ ] Improve documentation
- [ ] Other (please specify)


## Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have tested all links and they work
- [x] The resource is relevant to Omarchy
- [x] The description is clear and concise
- [x] I have followed the formatting guidelines
- [x] I have added the resource to the appropriate section
- [x] I have maintained alphabetical order within the section
- [x] The resource meets the quality standards outlined in CONTRIBUTING.md

