### PR TITLE
Add Okimarchy project link to Omarchy Alternative Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [armarchy](https://github.com/nilszeilon/armarchy) - ARM architecture-optimized fork of Omarchy.
 - [deckarchy](https://github.com/aorumbayev/deckarchy) - Steam Deck hardware fixes and optimizations for Omarchy installation.
 - [hyprwhspr](https://github.com/goodroot/hyprwhspr) - Native speech-to-text for Arch / Omarchy - Fast, accurate and easy system-wide Whisper dictation.
+- [Okimarchy](https://github.com/cristian-fleischer/okimarchy) - An Omarchy fork that adds support for niri window manager alongside Hyprland, with runtime switching and unified theming.
 - [omadora](https://github.com/elpritchos/omadora) - Minimal Fedora install based on Omarchy.
 - [omarchy-cachyos](https://github.com/lentra0/omarchy-cachyos) - Opinionated CachyOS/Hyprland Setup.
 - [omarchy-nix](https://github.com/henrysipp/omarchy-nix) - NixOS version of Omarchy with declarative configuration.


### PR DESCRIPTION
## Description
This PR adds Okimarchy to the Distro Integration section.

Okimarchy is an Omarchy fork that adds niri window manager support to Omarchy, with runtime switching capabilities, unified theming and configuration improvements.

Project link: https://github.com/cristian-fleischer/okimarchy

## Type of Contribution
- [x] New resource (theme, tool, tutorial, etc.)
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please specify)

## Resource Details
<!-- Fill out if adding a new resource -->
- **Resource Name**: Okimarchy
- **Category**: Omarchy Alternative Implementation
- **Link**: https://github.com/cristian-fleischer/okimarchy
- **Description**: Okimarchy is an Omarchy fork that adds niri window manager support to Omarchy, with runtime switching capabilities, unified theming and configuration improvements.

## Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have tested all links and they work
- [x] The resource is relevant to Omarchy
- [x] The description is clear and concise
- [x] I have followed the formatting guidelines
- [x] I have added the resource to the appropriate section
- [x] I have maintained alphabetical order within the section
- [x] The resource meets the quality standards outlined in CONTRIBUTING.md

## Additional Notes
This project aims to add support for niri as an alternative WM in Omarchy. It started as a pull request to Omarchy (https://github.com/basecamp/omarchy/pull/2042) which was (rightfully) declined as it would defeat the purpose of an Omakase distribution.
So the project was born as an Okimari distribution offering you the choice between Hyprland and niri as WMs, switchable at runtime. It follows all the principles of Omarchy as closly as possible and aims to offer the same experience just with niri as a WM.
