### PR TITLE
Add Fedpunk to Alternative Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 - [armarchy](https://github.com/nilszeilon/armarchy) - ARM architecture-optimized fork of Omarchy.
 - [deckarchy](https://github.com/aorumbayev/deckarchy) - Steam Deck hardware fixes and optimizations for Omarchy installation.
+- [Fedpunk](https://github.com/hinriksnaer/Fedpunk) - Omarchy-based desktop configuration and modular theming engine for Fedora.
 - [hyprwhspr](https://github.com/goodroot/hyprwhspr) - Native speech-to-text for Arch / Omarchy - Fast, accurate and easy system-wide Whisper dictation.
 - [Okimarchy](https://github.com/cristian-fleischer/okimarchy) - An Omarchy fork that adds support for niri window manager alongside Hyprland, with runtime switching and unified theming.
 - [omadora](https://github.com/elpritchos/omadora) - Minimal Fedora install based on Omarchy.


### PR DESCRIPTION
## Summary
- Adds Fedpunk to the Alternative Implementations section
- Fedpunk is an Omarchy-based desktop configuration and modular theming engine for Fedora

## Details
This PR adds [Fedpunk](https://github.com/hinriksnaer/Fedpunk) to the curated list of Omarchy alternative implementations. Fedpunk provides an Omarchy-inspired experience tailored for Fedora users with modular theming capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)