### PR TITLE
Add omarchy-vpn to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@
 - [OMARCHY-VM-UTM](https://github.com/hjanuschka/OMARCHY-VM-UTM) - OMARCHY VM for UTM - Pre-configured Arch Linux virtual machine.
 - [omarchy-workspace-mover](https://github.com/jonashan/omarchy-workspace-mover) - A Omarchy plugin for moving workspaces between monitors.
 - [omarchy-wireguard-vpn-toggle](https://github.com/JacobusXIII/omarchy-wireguard-vpn-toggle) - WireGuard VPN toggle for Omarchy's Waybar.
+- [omarchy-vpn](https://github.com/limehawk/omarchy-vpn) - WireGuard VPN manager TUI with live connection stats, inline config import/rename, and optional Waybar module.
 - [omazed](https://github.com/APS6/omazed) - Live theme switching for Zed editor in Omarchy.
 - [flutter_omarchy](https://github.com/aloisdeniel/flutter_omarchy) - Develop Flutter apps for Omarchy.
 - [omarchy-pkgs](https://github.com/omacom-io/omarchy-pkgs) - Official Omarchy packages and utilities.


### PR DESCRIPTION
## Description
Adding omarchy-vpn under Development Tools. It's a WireGuard manager for the terminal built with Bubble Tea. One screen: connect/disconnect, live transfer + handshake stats, and an inline filepicker for importing `.conf` files. Optional waybar module for status-bar integration.

## Type of Contribution
- [x] New resource (theme, tool, tutorial, etc.)
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please specify)

## Resource Details
- **Resource Name**: omarchy-vpn
- **Category**: Development Tools
- **Link**: https://github.com/limehawk/omarchy-vpn
- **Description**: WireGuard VPN manager TUI with live connection stats, inline config import/rename, and optional Waybar module.

## Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have tested all links and they work
- [x] The resource is relevant to Omarchy
- [x] The description is clear and concise
- [x] I have followed the formatting guidelines
- [x] I have added the resource to the appropriate section
- [ ] I have maintained alphabetical order within the section
- [x] The resource meets the quality standards outlined in CONTRIBUTING.md

## Additional Notes
Grouped next to `omarchy-wireguard-vpn-toggle` rather than strictly alphabetical, since both are WireGuard tools. Happy to move it if you'd prefer alphabetical. Also published to AUR as [omarchy-vpn](https://aur.archlinux.org/packages/omarchy-vpn).