### PR TITLE
Add omarchy-nook to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ A curated list of Omarchy themes, resources, and tools.
 - [omarchpods](https://github.com/tomycostantino/omarchpods) - TUI for monitoring AirPods and other Bluetooth headphones with battery status and device info.
 - [wayscriber](https://github.com/devmobasa/wayscriber) - Instant on-screen annotations and markup for Wayland, ZoomIt-inspired.
 - [lazyVPN-for-Omarchy](https://github.com/blank-query/lazyVPN-for-Omarchy) - A WireGuard VPN manager with Walker menu integration, killswitch protection, and dynamic server browsing.
+- [omarchy-nook](https://github.com/achevalier-dev/omarchy-nook) - Bar widget and menu for a home server on your tailnet, showing whether it answers, how it is doing, and what it is running.
 
 ## Related Projects
 


### PR DESCRIPTION
Adds [omarchy-nook](https://github.com/achevalier-dev/omarchy-nook) to **Development Tools**.

A bar widget and menu rows for a home server on your tailnet — a Pi, a mini PC, an old ThinkCentre. The glyph says whether the box answers; the panel carries temperature, disk, load, the services it is running (each one a click away in a browser), and only the actions that make sense right now — it will not offer *Eject* with nothing attached. The menu rows are generated from the boxes you have adopted, so with several machines each gets its own submenu and no row acts on a hidden default.

It is the front end for [nook](https://github.com/achevalier-dev/nook), the CLI behind it.

- MIT, first-party plugin conventions (`manifest.json` with `schemaVersion: 1`, settings schema, `allowMultiple` for one instance per box)
- Recorded demo in the README, plus a test suite (`./script/check`) covering the generated menu rows and every menu command
- Written against the current shell API: `Panel`, `KeyboardPanel`, `PanelHero`, `BarIconButton`

One thing up front, so you can judge it rather than discover it: the repository is new and has no stars yet, which is under the 5+ in CONTRIBUTING.md. Happy for this to wait until it clears the bar — I would rather it sit than bend the rule.