### PR TITLE
Add renCal to development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community plugins for [Omarchy Quattro](https://github.com/basecamp/omarchy/tree
 - [omarchy-workspace-mover](https://github.com/jonashan/omarchy-workspace-mover) - An Omarchy plugin for moving workspaces between monitors.
 - [omazed](https://github.com/APS6/omazed) - Live theme switching for Zed editor in Omarchy.
 - [Pacsea](https://github.com/Firstp1ck/Pacsea) - Rust TUI for browsing and queueing pacman/AUR packages, inspired by Omarchy's installer.
+- [renCal](https://github.com/t4t5/rencal) - Modern desktop calendar built for Omarchy that syncs with Google, iCloud, Outlook and CalDAV.
 - [tema](https://github.com/bjarneo/tema) - Modern Omarchy theming UI with live previews and presets.
 - [waybar-themes](https://github.com/HANCORE-linux/waybar-themes) - Collection of Waybar themes with various styles and combinations for Omarchy.
 - [wayscriber](https://github.com/devmobasa/wayscriber) - Instant on-screen annotations and markup for Wayland, ZoomIt-inspired.


### PR DESCRIPTION
## Description
Adds renCal, a desktop calendar app built for Omarchy, to the Development Tools section.

## Type of Contribution
- [x] New resource (theme, tool, tutorial, etc.)
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please specify)

## Resource Details
- **Resource Name**: renCal
- **Category**: Development Tools
- **Link**: https://github.com/t4t5/rencal
- **Description**: Modern desktop calendar built for Omarchy that syncs with Google, iCloud, Outlook and CalDAV.

## Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have tested all links and they work
- [x] The resource is relevant to Omarchy
- [x] The description is clear and concise
- [x] I have followed the formatting guidelines
- [x] I have added the resource to the appropriate section
- [x] I have maintained alphabetical order within the section
- [x] The resource meets the quality standards outlined in CONTRIBUTING.md

## Additional Notes
renCal is open source (100+ stars, actively maintained) and available on the AUR as `rencal-bin`.